### PR TITLE
Make Server.listen return self

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -18,4 +18,5 @@ Server.listen = function () {
     } else {
         oldListen.apply(self, arguments);
     }
+    return self;
 };


### PR DESCRIPTION
I had some trouble with node-systemd, but found the problem. The Server.listen function did not return anything (undefined) and some libraries need .listen to be returning this (like node does as well).

You can see that node does the same here:
https://github.com/joyent/node/blob/master/lib/net.js#L1180
