### PR TITLE
Allow listen calls to include hostname

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -7,7 +7,7 @@ var oldListen = Server.listen;
 Server.listen = function () {
     var self = this;
 
-    if (arguments.length === 1 && arguments[0] === 'systemd') {
+    if (arguments.length >= 1 && arguments[0] === 'systemd') {
         if (!process.env.LISTEN_FDS || parseInt(process.env.LISTEN_FDS, 10) !== 1) {
             throw(new Error('No or too many file descriptors received.'));
         }

--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -7,7 +7,7 @@ var oldListen = Server.listen;
 Server.listen = function () {
     var self = this;
 
-    if (arguments.length >= 1 && arguments[0] === 'systemd') {
+    if (arguments.length === 1 && arguments[0] === 'systemd') {
         if (!process.env.LISTEN_FDS || parseInt(process.env.LISTEN_FDS, 10) !== 1) {
             throw(new Error('No or too many file descriptors received.'));
         }
@@ -16,6 +16,10 @@ Server.listen = function () {
         self._handle.open(3);
         self._listen2(null, -1, -1);
     } else {
+        if (arguments.length >= 1 && arguments[0] === 'systemd') {
+            console.log('Too many arguments provided to systemd listen.');
+            console.trace();
+        }
         oldListen.apply(self, arguments);
     }
     return self;

--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -7,19 +7,22 @@ var oldListen = Server.listen;
 Server.listen = function () {
     var self = this;
 
-    if (arguments.length === 1 && arguments[0] === 'systemd') {
+    if (arguments.length >= 1 && arguments[0] === 'systemd') {
         if (!process.env.LISTEN_FDS || parseInt(process.env.LISTEN_FDS, 10) !== 1) {
             throw(new Error('No or too many file descriptors received.'));
         }
 
+        if (arguments.length >= 2  && typeof arguments[1] !== 'function') {
+            throw(new Error('Specifying host is not supported.'));
+        }
+        
         self._handle = new Pipe();
         self._handle.open(3);
         self._listen2(null, -1, -1);
-    } else {
-        if (arguments.length >= 1 && arguments[0] === 'systemd') {
-            console.log('Too many arguments provided to systemd listen.');
-            console.trace();
+        if (arguments.length >= 2 && typeof arguments[arguments.length-1] === 'function') {
+            self.on('listening', arguments[arguments.length-1]);
         }
+    } else {
         oldListen.apply(self, arguments);
     }
     return self;


### PR DESCRIPTION
Given the API definition "server.listen(port, [host], [backlog], [callback])", at least accept when someone specifies a host. For now, I'm ignoring it as the socket listener is systemd.
