### PR TITLE
Added the ability to use normal listen() arguments

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -7,14 +7,15 @@ var oldListen = Server.listen;
 Server.listen = function () {
     var self = this;
 
-    if (arguments.length === 1 && arguments[0] === 'systemd') {
+    if (arguments.length >= 1 && arguments[0] === 'systemd') {
         if (!process.env.LISTEN_FDS || parseInt(process.env.LISTEN_FDS, 10) !== 1) {
             throw(new Error('No or too many file descriptors received.'));
         }
 
         self._handle = new Pipe();
         self._handle.open(3);
-        self._listen2(null, -1, -1);
+        arguments[0] = self._handle;
+        oldListen.apply(self, arguments);
     } else {
         oldListen.apply(self, arguments);
     }


### PR DESCRIPTION
Wonderful node module, I only found one problem with it on my end
though. When I wanted to add a callback like normal, I couldn't do so
with systemd and it would just get passed back onto the old listener
object, which wasn't something that I wanted (obviously). Fixed that
along with the other operators. Judging by Node's code, this should work
and not have any negative side effects.

Signed-off-by: Colton Wolkins (Frostyfrog) frostyfrog2@gmail.com
