### PR TITLE
Fix for newer Node.JS

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -12,7 +12,7 @@ Server.listen = function () {
             throw(new Error('No or too many file descriptors received.'));
         }
 
-        self._handle = new Pipe();
+        self._handle = new Pipe(process.binding('pipe_wrap').constants.SOCKET);
         self._handle.open(3);
         self._listen2(null, -1, -1);
     } else {

--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -12,7 +12,12 @@ Server.listen = function () {
             throw(new Error('No or too many file descriptors received.'));
         }
 
-        self._handle = new Pipe(process.binding('pipe_wrap').constants.SOCKET);
+        if (!process.binding('pipe_wrap').Pipe.constants) {
+            self._handle = new Pipe();
+        }
+        else {
+            self._handle = new Pipe(process.binding('pipe_wrap').Pipe.constants.SOCKET);
+        }
         self._handle.open(3);
         self._listen2(null, -1, -1);
     } else {

--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -12,11 +12,11 @@ Server.listen = function () {
             throw(new Error('No or too many file descriptors received.'));
         }
 
-        if (!process.binding('pipe_wrap').Pipe.constants) {
-            self._handle = new Pipe();
+        if (process.binding('pipe_wrap').Pipe.constants && process.binding('pipe_wrap').Pipe.constants.SOCKET) {
+            self._handle = new Pipe(process.binding('pipe_wrap').Pipe.constants.SOCKET);
         }
         else {
-            self._handle = new Pipe(process.binding('pipe_wrap').Pipe.constants.SOCKET);
+            self._handle = new Pipe();
         }
         self._handle.open(3);
         self._listen2(null, -1, -1);


### PR DESCRIPTION
While trying to use this module with Node.JS 9.4.0 it was found that the module didn't work.

According to [this](https://github.com/nodejs/node/commit/b44efded8481877c1ec782112b9ae4c4fec37463) commit the **PipeWrap::New** function in the **pipe_wrap.cc** file checks for the type of the argument provided and
if the type of the argument doesn't match it throws an exception.