### PR TITLE
support standard net.Server.listen args

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -7,10 +7,23 @@ var Pipe = PipeWrap.Pipe;
 var oldListen = Server.listen;
 Server.listen = function () {
     var self = this;
+    var backlog;
+    var callback;
 
-    if (arguments.length === 1 && arguments[0] === 'systemd') {
+    if (arguments[0] === 'systemd') {
+        if (typeof arguments[1] === 'function') {
+            callback = arguments[1];
+        } else if (typeof arguments[1] === 'number') {
+            backlog = arguments[1];
+            callback = arguments[2];
+        }
+
         if (!process.env.LISTEN_FDS || parseInt(process.env.LISTEN_FDS, 10) !== 1) {
             throw(new Error('No or too many file descriptors received.'));
+        }
+
+        if (callback) {
+            self.once('listening', callback);
         }
 
         if (PipeWrap.constants && typeof PipeWrap.constants.SOCKET !== 'undefined') {
@@ -20,7 +33,7 @@ Server.listen = function () {
             self._handle = new Pipe();
         }
         self._handle.open(3);
-        self._listen2(null, -1, -1);
+        self._listen2(null, -1, -1, backlog);
     } else {
         oldListen.apply(self, arguments);
     }


### PR DESCRIPTION
Add support for **backlog** and **callback** arguments.  These arguments are supported by the standard net.Server.listen methods in Node.js, but with a systemd-patched Server instance, passing these arguments would cause an error and there was no straightforward workaround.

```
// previously, only this would work
server.listen("systemd");

// but if you tried this, you'd get an error
server.listen("systemd", 64, () => console.log("listening for clients"));
```